### PR TITLE
createUri changes due to new portal experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datastax/astra-db-ts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Astra DB TS Client",
   "contributors": [
     "CRW (http://barnyrubble.tumblr.com/)",

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -156,17 +156,9 @@ export class Client {
 
 export class AstraDB extends Client {
   constructor(...args: any[]) {
-    // token: string, path: string
-    if (args.length === 2) {
-      let endpoint = args[1];
-      endpoint += "/api/json/v1";
-      endpoint += "/default_keyspace";
-      super(endpoint, "default_keyspace", { isAstra: true, applicationToken: args[0] });
-    } else {
-      // token: string, dbId: string, region: string, keyspace?: string
-      const keyspaceName = args[3] || "default_keyspace";
-      const endpoint = createAstraUri(args[1], args[2], keyspaceName);
-      super(endpoint, keyspaceName, { isAstra: true, applicationToken: args[0] });
-    }
+    // token: string, API EndPoint: string, keyspace?: string
+    const keyspaceName = args[2] || "default_keyspace";
+    const endpoint = createAstraUri(args[1], keyspaceName);
+    super(endpoint, keyspaceName, { isAstra: true, applicationToken: args[0] });
   }
 }

--- a/src/collections/client.ts
+++ b/src/collections/client.ts
@@ -154,10 +154,12 @@ export class Client {
   }
 }
 
+const DEFAULT_KEYSPACE = "default_keyspace";
+
 export class AstraDB extends Client {
   constructor(...args: any[]) {
     // token: string, API EndPoint: string, keyspace?: string
-    const keyspaceName = args[2] || "default_keyspace";
+    const keyspaceName = args[2] || DEFAULT_KEYSPACE;
     const endpoint = createAstraUri(args[1], keyspaceName);
     super(endpoint, keyspaceName, { isAstra: true, applicationToken: args[0] });
   }

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -77,8 +77,7 @@ export function getKeyspaceName(pathFromUrl?: string | null) {
 
 /**
  * Create an Astra connection URI while connecting to Astra JSON API
- * @param databaseId the database id of the Astra database
- * @param region the region of the Astra database
+ * @param apiEndPoint the API EndPoint of the Astra database
  * @param keyspace the keyspace to connect to
  * @param applicationToken an Astra application token
  * @param baseApiPath baseAPI path defaults to /api/json/v1
@@ -87,17 +86,14 @@ export function getKeyspaceName(pathFromUrl?: string | null) {
  * @returns URL as string
  */
 export function createAstraUri(
-  databaseId: string,
-  region: string,
+  apiEndPoint: string,
   keyspace: string,
   applicationToken?: string,
   baseApiPath?: string,
   logLevel?: string,
   authHeaderName?: string,
 ) {
-  const uri = new url.URL(
-    `https://${databaseId}-${region}.apps.astra.datastax.com`,
-  );
+  const uri = new url.URL(apiEndPoint);
   let contextPath = "";
   contextPath += baseApiPath ? `/${baseApiPath}` : "/api/json/v1";
   contextPath += `/${keyspace}`;

--- a/tests/collections/utils.test.ts
+++ b/tests/collections/utils.test.ts
@@ -14,62 +14,55 @@
 
 import assert from "assert";
 import { createAstraUri } from "@/src/collections/utils";
+import {AstraDB, Client} from "@/src/collections";
 
 describe("Utils test", () => {
+  it("ClientBaseUriTest", () => {
+    const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+    const astraDb = new AstraDB("myToken",apiEndPoint,"testks1");
+    assert.strictEqual(
+        astraDb.httpClient.baseUrl,
+        "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1",
+    );
+  });
+  it("ClientBaseUriTestDefaultKeyspace", () => {
+    const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+    const astraDb = new AstraDB("myToken",apiEndPoint);
+    assert.strictEqual(
+        astraDb.httpClient.baseUrl,
+        "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/default_keyspace",
+    );
+  });
   it("createProdAstraUri", () => {
-    const dbIdUUID = "ddd5843c-3dea-11ee-be56-0242ac120002";
-    const uri: string = createAstraUri(dbIdUUID, "us-east1", "testks1");
+    const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+    const uri: string = createAstraUri( apiEndPoint, "testks1");
     assert.strictEqual(
       uri,
-      "https://" +
-        dbIdUUID +
-        "-us-east1.apps.astra.datastax.com/api/json/v1/testks1",
+      "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1",
     );
   });
   it("createProdAstraUriWithToken", () => {
-    const dbIdUUID = "ddd5843c-3dea-11ee-be56-0242ac120002";
-    const uri: string = createAstraUri(
-      dbIdUUID,
-      "us-east1",
-      "testks1",
-      "myToken",
-    );
+    const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+    const uri: string = createAstraUri( apiEndPoint, "testks1", "myToken");
     assert.strictEqual(
-      uri,
-      "https://" +
-        dbIdUUID +
-        "-us-east1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken",
+        uri,
+        "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken",
     );
   });
   it("createProdAstraUriWithTokenAndProdEnum", () => {
-    const dbIdUUID = "ddd5843c-3dea-11ee-be56-0242ac120002";
-    const uri: string = createAstraUri(
-      dbIdUUID,
-      "us-east1",
-      "testks1",
-      "myToken",
-    );
-    assert.strictEqual(
-      uri,
-      "https://" +
-        dbIdUUID +
-        "-us-east1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken",
-    );
-  });
+      const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+      const uri: string = createAstraUri( apiEndPoint, "testks1", "myToken");
+      assert.strictEqual(
+          uri,
+          "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/api/json/v1/testks1?applicationToken=myToken",
+      );
+    });
   it("createProdAstraUriWithTokenAndProdEnumWithBaseAPIPath", () => {
-    const dbIdUUID = "ddd5843c-3dea-11ee-be56-0242ac120002";
-    const uri: string = createAstraUri(
-      dbIdUUID,
-      "us-east1",
-      "testks1",
-      "myToken",
-      "apis",
-    );
+    const apiEndPoint = "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com";
+    const uri: string = createAstraUri( apiEndPoint, "testks1", "myToken","apis");
     assert.strictEqual(
-      uri,
-      "https://" +
-        dbIdUUID +
-        "-us-east1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken",
+        uri,
+        "https://a5cf1913-b80b-4f44-ab9f-a8b1c98469d0-ap-south-1.apps.astra.datastax.com/apis/testks1?applicationToken=myToken",
     );
   });
 });


### PR DESCRIPTION

Support keyspace rather than just default_keyspace when use API EndPoint from new portal UI
Align with stargate-mongoose, abandon the use of db_id and region method.

Fix: https://github.com/datastax/astra-db-ts/issues/10