### PR TITLE
docs: link to client reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ async function main() {
 
 main().catch(console.error);
 ```
+
+## Usage
+
+Refer to the API [reference documentation](https://docs.datastax.com/en/astra/astra-db-vector/clients/typescript.html) for more information and usage examples. 


### PR DESCRIPTION
Link to our [datastax client reference documentation](https://docs.datastax.com/en/astra/astra-db-vector/clients/typescript.html) to help guide folks to more usage examples. Fixes #13 .