### PR TITLE
Minor 1.0.1 patches

### DIFF
--- a/etc/astra-db-ts.api.md
+++ b/etc/astra-db-ts.api.md
@@ -986,6 +986,8 @@ export type StrictPop<Schema extends SomeDoc, InNotation = ToDotNotation<Schema>
 // @public
 export type StrictProjection<Schema extends SomeDoc> = {
     [K in keyof ToDotNotation<WithId<Schema>>]?: any[] extends (ToDotNotation<WithId<Schema>>)[K] ? 1 | 0 | true | false | ProjectionSlice : 1 | 0 | true | false;
+} & {
+    '*': 1 | 0 | true | false;
 };
 
 // @public

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -14,14 +14,15 @@
 
 import { LIB_NAME, LIB_VERSION } from '@/src/version';
 
+/**
+ * @internal
+ */
 export const RAGSTACK_REQUESTED_WITH = (() => {
   try {
-    /**
-     * Do not use require() here, it will break the build in some environments such as NextJS application^M
-     * if @datastax/ragstack-ai is not installed (which is perfectly fine).
-     */
+    // Do not use require() here, it will break the build in some environments such as NextJS application
+    // if @datastax/ragstack-ai is not installed (which is perfectly fine).
     const ragstack = eval(`require('@datastax/ragstack-ai')`);
-    const version =  ragstack['RAGSTACK_VERSION'] || "?";
+    const version = ragstack['RAGSTACK_VERSION'] || '?';
     return `ragstack-ai-ts/${version}`
   } catch (e) {
     return '';

--- a/src/api/http-client.ts
+++ b/src/api/http-client.ts
@@ -91,6 +91,9 @@ export function hrTimeMs(): number {
   return Math.floor(hrtime[0] * 1000 + hrtime[1] / 1000000);
 }
 
+/**
+ * @internal
+ */
 export function buildUserAgent(caller: Caller | Caller[] | undefined): string {
   const callers = (
     (!caller)

--- a/src/data-api/collection.ts
+++ b/src/data-api/collection.ts
@@ -551,6 +551,7 @@ export class Collection<Schema extends SomeDoc = SomeDoc> {
           returnDocument: 'before',
           upsert: options?.upsert,
         },
+        // projection: { '*': 0 },
       },
     };
 

--- a/src/data-api/db.ts
+++ b/src/data-api/db.ts
@@ -288,8 +288,8 @@ export class Db {
    * This is a blocking command which performs actual I/O unlike {@link Db.collection}, which simply creates an
    * unvalidated reference to a collection.
    *
-   * **Creation is idempotent, so if the collection already exists with the same options, this method will not throw
-   * an error. If the options differ though, it'll raise an error.**
+   * **If `checkExists: false`, creation is idempotent, so if the collection already exists with the same options,
+   * this method will not throw an error. If the options differ though, it'll raise an error.**
    *
    * Typed as `Collection<SomeDoc>` by default, but you can specify a schema type to get a typed collection. If left
    * as `SomeDoc`, the collection will be untyped.

--- a/src/data-api/types/common.ts
+++ b/src/data-api/types/common.ts
@@ -156,6 +156,8 @@ export type StrictProjection<Schema extends SomeDoc> = {
   [K in keyof ToDotNotation<WithId<Schema>>]?: any[] extends (ToDotNotation<WithId<Schema>>)[K]
     ? 1 | 0 | true | false | ProjectionSlice
     : 1 | 0 | true | false;
+} & {
+  '*': 1 | 0 | true | false;
 };
 
 /**

--- a/tests/integration/data-api/collection/replace-one.test.ts
+++ b/tests/integration/data-api/collection/replace-one.test.ts
@@ -67,12 +67,30 @@ describe('integration.data-api.collection.replace-one', () => {
     assert.strictEqual(resp.modifiedCount, 1);
   });
 
-  it('should replaceOne with upsert true', async () => {
+  it('should replaceOne with upsert true if match', async () => {
+    await collection.insertOne({ _id: 1 });
+    const resp = await collection.replaceOne(
+      {
+        _id: 1,
+      },
+      createSampleDoc2WithMultiLevel(),
+      {
+        upsert: true,
+      },
+    );
+
+    assert.strictEqual(resp.matchedCount, 1);
+    assert.strictEqual(resp.modifiedCount, 1);
+    assert.strictEqual(resp.upsertedCount, 0);
+    assert.strictEqual(resp.upsertedId, undefined);
+  });
+
+  it('should replaceOne with upsert true if no match', async () => {
     await collection.insertOne(createSampleDocWithMultiLevel());
     const newDocId = '123';
     const resp = await collection.replaceOne(
       {
-        '_id': newDocId,
+        _id: newDocId,
       },
       createSampleDoc2WithMultiLevel(),
       {


### PR DESCRIPTION
1. Updated createCollection documentation to mention `checkExists`
2. Fixed ragstack detection formatting slightly to keep in-line w/ codebase
3. Added couple replaceOne tests
4. Marked some things @internal that weren't already
5. `'*'` support for projections