### PR TITLE
throw readable error if passing endpoint and keyspace as a string to db()

### DIFF
--- a/src/data-api/db.ts
+++ b/src/data-api/db.ts
@@ -490,7 +490,7 @@ export function mkDb(rootOpts: InternalRootClientOpts, endpointOrId: string, reg
   validateDbOpts(options);
 
   if (typeof regionOrOptions === 'string' && endpointOrId.startsWith('https://')) {
-    throw new Error('Unexpected regionOrOptions parameter: must be options object if endpointOrId starts with "https://"');
+    throw new Error('Unexpected db() argument: database id can\'t start with "https://". Did you mean to call `.db(endpoint, { namespace })`?');
   }
  
   const endpoint = (typeof regionOrOptions === 'string')

--- a/src/data-api/db.ts
+++ b/src/data-api/db.ts
@@ -489,6 +489,10 @@ export function mkDb(rootOpts: InternalRootClientOpts, endpointOrId: string, reg
 
   validateDbOpts(options);
 
+  if (typeof regionOrOptions === 'string' && endpointOrId.startsWith('https://')) {
+    throw new Error('Unexpected regionOrOptions parameter: must be options object if endpointOrId starts with "https://"');
+  }
+ 
   const endpoint = (typeof regionOrOptions === 'string')
     ? 'https://' + endpointOrId + '-' + regionOrOptions + '.apps.astra.datastax.com'
     : endpointOrId;

--- a/tests/integration/client/data-api-client.test.ts
+++ b/tests/integration/client/data-api-client.test.ts
@@ -286,5 +286,13 @@ describe('integration.client.data-api-client', () => {
       assert.ok(failedEvent.error instanceof DataAPITimeoutError);
       assert.strictEqual(failedEvent.error.timeout, 1);
     });
+
+    it('throws an error if passing in endpoint and keyspace name as a string', () => {
+      const client = new DataAPIClient(TEST_APPLICATION_TOKEN);
+      assert.throws(
+        () => client.db(TEST_ASTRA_URI, OTHER_NAMESPACE),
+        { message: 'Unexpected regionOrOptions parameter: must be options object if endpointOrId starts with "https://"' }
+      );
+    });
   });
 });

--- a/tests/integration/client/data-api-client.test.ts
+++ b/tests/integration/client/data-api-client.test.ts
@@ -291,7 +291,7 @@ describe('integration.client.data-api-client', () => {
       const client = new DataAPIClient(TEST_APPLICATION_TOKEN);
       assert.throws(
         () => client.db(TEST_ASTRA_URI, OTHER_NAMESPACE),
-        { message: 'Unexpected regionOrOptions parameter: must be options object if endpointOrId starts with "https://"' }
+        { message: 'Unexpected db() argument: database id can\'t start with "https://". Did you mean to call `.db(endpoint, { namespace })`?' }
       );
     });
   });


### PR DESCRIPTION
An error I ran into the other day while getting set up with this project: if you do `client.db(endpoint, namespace)` instead of `client.db(endpoint, { namespace })` you get some unreadable dns errors. This PR adds better handling for that case.