### PR TITLE
correct DSE token

### DIFF
--- a/src/common/token-providers/dse-token-providers.ts
+++ b/src/common/token-providers/dse-token-providers.ts
@@ -38,7 +38,7 @@ export class DSEUsernamePasswordTokenProvider extends TokenProvider {
    */
   constructor(username: string, password: string) {
     super();
-    this.#token = `cassandra:${this._encodeB64(username)}:${this._encodeB64(password)}`;
+    this.#token = `Cassandra:${this._encodeB64(username)}:${this._encodeB64(password)}`;
   }
 
   /**

--- a/tests/unit/common/token-providers.test.ts
+++ b/tests/unit/common/token-providers.test.ts
@@ -29,7 +29,7 @@ describe('unit.common.token-providers', () => {
   describe('DSEUsernamePasswordTokenProvider', () => {
     it('should provide the properly encoded cassandra token in node', async () => {
       const tp = new DSEUsernamePasswordTokenProvider('username', 'password');
-      assert.strictEqual(await tp.getTokenAsString(), 'cassandra:dXNlcm5hbWU=:cGFzc3dvcmQ=');
+      assert.strictEqual(await tp.getTokenAsString(), 'Cassandra:dXNlcm5hbWU=:cGFzc3dvcmQ=');
     });
 
     it('should provide the properly encoded cassandra token in the browser', async () => {
@@ -38,7 +38,7 @@ describe('unit.common.token-providers', () => {
       anyGlobalThis.window = { btoa: anyGlobalThis.btoa };
       anyGlobalThis.Buffer = null!;
       const tp = new DSEUsernamePasswordTokenProvider('username', 'password');
-      assert.strictEqual(await tp.getTokenAsString(), 'cassandra:dXNlcm5hbWU=:cGFzc3dvcmQ=');
+      assert.strictEqual(await tp.getTokenAsString(), 'Cassandra:dXNlcm5hbWU=:cGFzc3dvcmQ=');
 
       [anyGlobalThis.window, anyGlobalThis.Buffer] = [window, buffer];
     });


### PR DESCRIPTION
AFAIK the correct DSE token starts with "Cassandra" with an uppercase "C". [That's how stargate-mongoose does it](https://github.com/stargate/stargate-mongoose/blob/490e52e4faa1a9bdd1a2887d509c24df6c21d6ae/src/collections/utils.ts#L135), and from what I can tell stargate auth always fails with a lowercase "c".