### PR TITLE
Strips trailing slashes from API endpoint.

### DIFF
--- a/src/data-api/db.ts
+++ b/src/data-api/db.ts
@@ -98,6 +98,8 @@ export class Db {
 
     this.#token = TokenProvider.parseToken(dbOpts?.token ?? rootOpts.dbOptions.token);
 
+    endpoint = endpoint.endsWith('/') ? endpoint.replace(/\/+$/, "") : endpoint;
+
     const combinedDbOpts = {
       ...rootOpts.dbOptions,
       ...dbOpts,

--- a/tests/unit/data-api/db.test.ts
+++ b/tests/unit/data-api/db.test.ts
@@ -43,6 +43,11 @@ describe('unit.data-api.db', () => {
       const client = new DataAPIClient();
       assert.doesNotThrow(() => client.db(TEST_APPLICATION_URI));
     });
+
+    it('should strip trailing slashes from the endpoint', () => {
+      const db = new Db('https://id-region.apps.astra.datastax.com/', internalOps(), null);
+      assert.strictEqual(db['_httpClient'].baseUrl, `https://id-region.apps.astra.datastax.com/${DEFAULT_DATA_API_PATHS['astra']}`);
+    })
   });
 
   describe('mkDb tests', () => {


### PR DESCRIPTION
If you provide the API endpoint with a trailing slash, then the URL that is formed has 2 slashes in. This causes a 500 error when making requests to the Data API. The 500 error is not clear about the cause, it's a very generic openresty error, so stripping trailing slashes saves time in debugging a non-obvious issue.