### PR TITLE
 Strips trailing slashes from API endpoint.

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -150,6 +150,8 @@ export class Db extends HierarchicalEmitter<CommandEventMap> {
         : this.#defaultOpts.dbOptions.keyspace ?? undefined,
     };
 
+    endpoint = endpoint.endsWith('/') ? endpoint.replace(/\/+$/, "") : endpoint;
+
     this.#httpClient = new DataAPIHttpClient({
       baseUrl: endpoint,
       tokenProvider: this.#defaultOpts.dbOptions.token,

--- a/tests/unit/db/db.test.ts
+++ b/tests/unit/db/db.test.ts
@@ -43,6 +43,11 @@ describe('unit.db.db', () => {
       const client = new DataAPIClient();
       assert.doesNotThrow(() => client.db(TEST_APPLICATION_URI));
     });
+
+    it("should strip trailing slashes from the endpoint", () => {
+      const db = new Db(internalOps(), "https://id-region.apps.astra.datastax.com/", DbOptsHandler.empty);
+      assert.strictEqual(db["_httpClient"].baseUrl, `https://id-region.apps.astra.datastax.com/${DEFAULT_DATA_API_PATHS["astra"]}`));
+    });
   });
 
   describe('new Db tests', () => {


### PR DESCRIPTION
If you provide the API endpoint with a trailing slash, then the URL that is formed has 2 slashes in. This causes a 500 error when making requests to the Data API. The 500 error is not clear about the cause, it's a very generic openresty error, so stripping trailing slashes saves time in debugging a non-obvious issue.

Just moving the work from #105 to the v2.0 branch.